### PR TITLE
Do not mark the backend as working in InProcessStore on every is_broken call

### DIFF
--- a/failfast/store.py
+++ b/failfast/store.py
@@ -39,7 +39,7 @@ class InProcessStore(Store):
         self._data.pop(key, None)
 
     def is_broken(self, key: str) -> bool:
-        return self._data.pop(key, 0) > self._clock()
+        return self._data.get(key, 0) > self._clock()
 
 
 class DjangoCacheStore(Store):

--- a/failfast/tests/store_tests.py
+++ b/failfast/tests/store_tests.py
@@ -20,23 +20,27 @@ def test_inprocess_store() -> None:
     store.set_broken("some_backend", 10)
 
     assert store.is_broken("some_backend")
+    assert store.is_broken("some_backend")
 
 
 def test_inprocess_expired() -> None:
-    clock_mock = Mock(side_effect=[NOW, NOW + 10])
+    clock_mock = Mock(side_effect=[NOW, NOW, NOW, NOW + 10])
     store = InProcessStore(clock=clock_mock)
 
     store.set_broken("some_backend", 5)
 
+    assert store.is_broken("some_backend")
+    assert store.is_broken("some_backend")
     assert not store.is_broken("some_backend")
 
 
 def test_inprocess_not_expired() -> None:
-    clock_mock = Mock(side_effect=[NOW, NOW + 10])
+    clock_mock = Mock(side_effect=[NOW, NOW + 10, NOW + 10])
     store = InProcessStore(clock=clock_mock)
 
     store.set_broken("some_backend", 15)
 
+    assert store.is_broken("some_backend")
     assert store.is_broken("some_backend")
 
 


### PR DESCRIPTION
Now it is marked as broken until the timeout, like the DjangoCacheStore.